### PR TITLE
Fix error on server on load

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -19,7 +19,9 @@ Config.Shops = {
 	vector3(-293.7, 6200.0, 31.4)
 }
 
-Config.interiorIds = {}
-for k, v in ipairs(Config.Shops) do
-    Config.interiorIds[#Config.interiorIds + 1] = GetInteriorAtCoords(v)
+if not IsDuplicityVersion() then
+	Config.interiorIds = {}
+	for k, v in ipairs(Config.Shops) do
+		Config.interiorIds[#Config.interiorIds + 1] = GetInteriorAtCoords(v)
+	end
 end


### PR DESCRIPTION
`config.lua` is shared between client and server however this piece of code is only for client side
Added check so its not ran on the server end.
Alternative is to remove the config from server scripts however it will probably be used for other things (adding payment amounts etc)